### PR TITLE
Fixes #25. Safari style fixes.

### DIFF
--- a/src/lib/Knobby.svelte
+++ b/src/lib/Knobby.svelte
@@ -257,7 +257,7 @@
 		opacity: 0.2;
 	}
 
-	.title-bar > :hover svg {
+	.title-bar svg:hover {
 		opacity: 1;
 	}
 
@@ -349,5 +349,9 @@
 
 	.knobby :global(.knobby-row:focus-within > :first-child) {
 		font-weight: bold;
+	}
+
+	.knobby :global(summary::-webkit-details-marker) {
+		display:none;
 	}
 </style>

--- a/src/lib/knobs/Folder.svelte
+++ b/src/lib/knobs/Folder.svelte
@@ -41,7 +41,6 @@
 	}
 
 	summary {
-		display: flex;
 		position: relative;
 		font-size: 13px;
 		list-style: none;


### PR DESCRIPTION
Removes duplicate open caret in title-bar.

Fix moving caret on hover.

Fixed opacity transition on top title-bar caret. 